### PR TITLE
packaging: arch: Do not report removal errors if booster image does not exist

### DIFF
--- a/packaging/arch/booster-remove
+++ b/packaging/arch/booster-remove
@@ -26,5 +26,5 @@ for kernel in "${kernels[@]}"; do
   fi
   read -r pkgbase < "${kernel}/pkgbase"
 
-  rm /boot/booster-${pkgbase}.img
+  rm -f /boot/booster-${pkgbase}.img
 done


### PR DESCRIPTION
Some users may delete booster images if they create UKI files.
Do not report removal errors if file does not exist.

mkinitcpio deletes files with the -f option:
https://github.com/archlinux/mkinitcpio/blob/ffae4b4821aa7d12271165cacf87d6772c70a8b4/libalpm/scripts/mkinitcpio#L115
